### PR TITLE
修改还未登录就显示登陆状态的bug

### DIFF
--- a/chapter-11/bbs-mobx/src/components/Header/index.js
+++ b/chapter-11/bbs-mobx/src/components/Header/index.js
@@ -14,7 +14,7 @@ class Header extends Component {
           <span className="left-link">
             <Link to="/">首页</Link>
           </span>
-          {authStore.username && authStore.username.length > 0 ? (
+          {authStore.userId && authStore.userId.length > 0 ? (
             <span className="user">
               当前用户：{authStore.username}&nbsp;<button onClick={authStore.logout}>
                 注销

--- a/chapter-11/bbs-mobx/src/stores/AuthStore.js
+++ b/chapter-11/bbs-mobx/src/stores/AuthStore.js
@@ -38,9 +38,9 @@ class AuthStore {
   }
 
   @action.bound logout() {
-    this.userId = null;
-    this.username = null;
-    this.password = null;
+    this.userId = undefined;
+    this.username = 'jack';
+    this.password = '123456';
     sessionStorage.removeItem("userId");
     sessionStorage.removeItem("username");
   }


### PR DESCRIPTION
现在在未登录的时候Header组件就会显示用户名
因为AuthStore初始化了username 和 password（主要用于登陆的数据框的初始化数据），但是Header组件中通过username判断是否登陆，就不正确了，应该用userId